### PR TITLE
Update Alpine Linux and packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM --platform=linux/amd64 alpine:3.20.3
+FROM --platform=linux/amd64 alpine:3.21.3
 WORKDIR /opt/
 ENV ENV="/root/.profile"
-RUN apk add --no-cache curl bind-tools jq yq hey aws-cli && \
+RUN apk update && apk upgrade && apk add --no-cache curl bind-tools jq yq hey aws-cli && \
     wget https://github.com/ktr0731/evans/releases/download/v0.10.11/evans_linux_amd64.tar.gz && \
     tar -xvf evans_linux_amd64.tar.gz &&    \
     mv ./evans /bin/ && \


### PR DESCRIPTION
This commit updates the base Alpine Linux image in your Dockerfile from version 3.20.3 to 3.21.3.

It also adds `apk update && apk upgrade` to the package installation step to ensure all installed apk packages (curl, bind-tools, jq, yq, hey, aws-cli) are updated to their latest available versions within the new Alpine base.

The versions of `evans` and `ghz` were checked and found to be already at their latest releases, so no changes were made to them.
